### PR TITLE
chore: pin Python to 3.12 for Mend visibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "vespaembed"
 version = "0.0.6"
 description = "vespaembed: no-code training for embedding models"
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12,<3.13"
 license = {text = "Apache 2.0"}
 authors = [
     {name = "Abhishek Thakur"}


### PR DESCRIPTION
> ⚠️ **This PR was created by an AI assistant (Claude). Please review carefully before merging.**

## Summary
Tightens `requires-python` in `pyproject.toml` from `>=3.11` to `>=3.12,<3.13` so Mend's dependency scanner narrows its CVE matching to Python 3.12 wheels (the version this project actually runs on).

## Changed Files
- `pyproject.toml`: `requires-python = ">=3.11"` → `requires-python = ">=3.12,<3.13"`

## Notes
- `.python-version` is gitignored in this repo, so the version pin lives in pyproject.toml only.
- This PR makes no source or dependency changes; it is a pure metadata / Mend-visibility update and is independent of any open CVE-fix PRs in this repo (e.g. #5).
- After merge, the next Mend scan should narrow its wheel matrix to `cp312` and stop reporting cross-version-irrelevant findings.

## Verification
- `python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['requires-python'])"` → `>=3.12,<3.13`